### PR TITLE
CSP and ko mapping support, using struct instead of interface to avoid some issues

### DIFF
--- a/knockout_secure_binding.go
+++ b/knockout_secure_binding.go
@@ -1,0 +1,33 @@
+package ko
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// var options = {
+//    attribute: "data-bind",        // default "data-sbind"
+//    globals: window,               // default {}
+//    bindings: ko.bindingHandlers,  // default ko.bindingHandlers
+//    noVirtualElements: false       // default true
+// };
+// ko.bindingProvider.instance = new ko.secureBindingsProvider(options);
+
+// Knockout Secure Binding (KSB) is a binding provider for Knockout
+// that can be used with a Content Security Policy (CSP)
+// that disables eval and new Function.
+//
+// Use this function to make gopherjs-ko works under chrome app/extensions.
+//
+// Must load knockout-secure-binding.min.js first:
+// https://github.com/brianmhunt/knockout-secure-binding
+func EnableSecureBinding() {
+	ko := js.Global.Get("ko")
+	secureBindingsProvider := ko.Get("secureBindingsProvider")
+	ksbp := secureBindingsProvider.New(js.M{
+		"attribute":         "data-bind",               // default "data-sbind"
+		"globals":           js.Global.Get("window"),   // default {}
+		"bindings":          ko.Get("bindingHandlers"), // default ko.bindingHandlers
+		"noVirtualElements": false,                     // default true
+	})
+	ko.Get("bindingProvider").Set("instance", ksbp)
+}

--- a/knockout_secure_binding.go
+++ b/knockout_secure_binding.go
@@ -11,7 +11,7 @@ import (
 //    noVirtualElements: false       // default true
 // };
 // ko.bindingProvider.instance = new ko.secureBindingsProvider(options);
-
+//
 // Knockout Secure Binding (KSB) is a binding provider for Knockout
 // that can be used with a Content Security Policy (CSP)
 // that disables eval and new Function.

--- a/ko.go
+++ b/ko.go
@@ -3,144 +3,237 @@
 // Using EnableSecureBinding make KnockoutJS works under CSP environments.
 package ko
 
-import "github.com/gopherjs/gopherjs/js"
+import (
+	"github.com/Archs/js/dom"
 
-type Disposable interface {
-	Dispose()
+	"github.com/gopherjs/gopherjs/js"
+)
+
+type Disposer func()
+
+type Observable struct {
+	o *js.Object
 }
 
-type Observable interface {
-	Disposable
-
-	Set(interface{})
-	Get() *js.Object
-	Subscribe(func(*js.Object)) Disposable
-	Extend(js.M) Observable
+type ObservableArray struct {
+	*Observable
 }
 
-type ObservableArray interface {
-	Observable
-
-	Index(int) *js.Object
-	Length() int
-	Push(interface{})
-	Remove(interface{}) *js.Object
-	RemoveFunc(func(*js.Object) bool) *js.Object
+type Computed struct {
+	*Observable
 }
 
-type Computed interface {
-	Observable
+type WritableComputed struct {
+	*Computed
 }
 
-type Object struct {
-	*js.Object
+func (ob *Observable) Set(data interface{}) {
+	ob.o.Invoke(data)
 }
 
-func (ob *Object) Dispose() {
-	ob.Call("dispose")
+func (ob *Observable) Get() *js.Object {
+	return ob.o.Invoke()
 }
 
-func (ob *Object) Set(data interface{}) {
-	ob.Invoke(data)
+func (ob *Observable) Subscribe(fn func(*js.Object)) Disposer {
+	o := ob.o.Call("subscribe", fn)
+	return func() {
+		o.Invoke()
+	}
 }
 
-func (ob *Object) Get() *js.Object {
-	return ob.Invoke()
-}
-
-func (ob *Object) Subscribe(fn func(*js.Object)) Disposable {
-	return &Object{ob.Call("subscribe", fn)}
-}
-
-func (ob *Object) Extend(params js.M) Observable {
-	ob.Call("extend", params)
+func (ob *Observable) Extend(params js.M) *Observable {
+	ob.o.Call("extend", params)
 	return ob
 }
 
-func (ob *Object) Index(i int) *js.Object {
+// The rateLimit extender, however, causes an observable to suppress and delay change notifications for a specified period of time. A rate-limited observable therefore updates dependencies asynchronously.
+//
+// The rateLimit extender can be applied to any type of observable, including observable arrays and computed observables. The main use cases for rate-limiting are:
+//
+// 		1. Making things respond after a certain delay
+// 		2. Combining multiple changes into a single update
+//
+// when "notifyWhenChangesStop" is true change envent will be fired only after no change event detects anymore.
+// "notifyWhenChangesStop" default is false, then it works under "notifyAtFixedRate" mode, at most one change in one timeframe.
+func (ob *Observable) RateLimit(timeframeMS int, notifyWhenChangesStop ...bool) {
+	method := "notifyAtFixedRate"
+	if len(notifyWhenChangesStop) >= 1 && notifyWhenChangesStop[0] {
+		method = "notifyWhenChangesStop"
+	}
+	ob.Extend(js.M{
+		"rateLimit": js.M{
+			"timeout": timeframeMS,
+			"method":  method,
+		},
+	})
+}
+
+// When a computed observable returns a primitive value (a number, string, boolean, or null),
+// the dependencies of the observable are normally only notified if the value actually changed.
+// However, it is possible to use the built-in notify extender to ensure
+// that a computed observable’s subscribers are always notified on an update,
+// even if the value is the same.
+func (ob *Observable) NotifyAlways() {
+	ob.Extend(js.M{
+		"notify": "always",
+	})
+}
+
+// adds a new item to the end of array
+func (ob *ObservableArray) IndexOf(data interface{}) int {
+	return ob.o.Call("indexOf", data).Int()
+}
+
+// removes the last value from the array and returns it
+func (ob *ObservableArray) Pop() *js.Object {
+	return ob.o.Call("pop")
+}
+
+// inserts a new item at the beginning of the array
+func (ob *ObservableArray) Unshift(data interface{}) {
+	ob.o.Call("unshift", data)
+}
+
+// removes the first value from the array and returns it
+func (ob *ObservableArray) Shift() *js.Object {
+	return ob.o.Call("shift")
+}
+
+func (ob *ObservableArray) Reverse() {
+	ob.o.Call("reverse")
+}
+
+func (ob *ObservableArray) Sort() {
+	ob.o.Call("sort")
+}
+
+func (ob *ObservableArray) SortFunc(fn func(*js.Object, *js.Object)) {
+	ob.o.Call("sort", fn)
+}
+
+// removes and returns a given number of elements starting from a given index.
+// For example,
+// 		myObservableArray.splice(1, 3)
+// removes three elements starting from index position 1
+// (i.e., the 2nd, 3rd, and 4th elements) and returns them as an array.
+func (ob *ObservableArray) Splice(i, n int) *js.Object {
+	return ob.o.Call("splice", i, n)
+}
+
+func (ob *ObservableArray) RemoveAll(items ...interface{}) *js.Object {
+	return ob.o.Call("removeAll", items...)
+}
+
+func (ob *ObservableArray) Index(i int) *js.Object {
 	return ob.Get().Index(i)
 }
 
-func (ob *Object) Length() int {
+func (ob *ObservableArray) Length() int {
 	return ob.Get().Length()
 }
 
-func (ob *Object) IndexOf(data interface{}) int {
-	return ob.Call("indexOf", data).Int()
+func (ob *ObservableArray) Push(data interface{}) {
+	ob.o.Call("push", data)
 }
 
-func (ob *Object) Push(data interface{}) {
-	ob.Call("push", data)
+func (ob *ObservableArray) Remove(item interface{}) *js.Object {
+	return ob.o.Call("remove", item)
 }
 
-func (ob *Object) Pop() *js.Object {
-	return ob.Call("pop")
-}
-
-func (ob *Object) Unshift(data interface{}) {
-	ob.Call("unshift", data)
-}
-
-func (ob *Object) Shift() *js.Object {
-	return ob.Call("shift")
-}
-
-func (ob *Object) Reverse() {
-	ob.Call("reverse")
-}
-
-func (ob *Object) Sort() {
-	ob.Call("sort")
-}
-
-func (ob *Object) SortFunc(fn func(*js.Object, *js.Object)) {
-	ob.Call("sort", fn)
-}
-
-func (ob *Object) Splice(i, n int) *js.Object {
-	return ob.Call("splice", i, n)
-}
-
-func (ob *Object) Remove(item interface{}) *js.Object {
-	return ob.Call("remove", item)
-}
-
-func (ob *Object) RemoveFunc(fn func(*js.Object) bool) *js.Object {
-	return ob.Call("remove", fn)
-}
-
-func (ob *Object) RemoveAll(items ...interface{}) *js.Object {
-	return ob.Call("removeAll", items...)
+func (ob *ObservableArray) RemoveFunc(fn func(*js.Object) bool) *js.Object {
+	return ob.o.Call("remove", fn)
 }
 
 type ComponentsFuncs struct {
-	*js.Object
+	o *js.Object
 }
 
 func Components() *ComponentsFuncs {
 	return &ComponentsFuncs{
-		Object: Global().Get("components"),
+		o: ko().Get("components"),
 	}
 }
 
 func (co *ComponentsFuncs) Register(name string, params js.M) {
-	co.Call("register", name, params)
+	co.o.Call("register", name, params)
 }
 
-func Global() *js.Object {
+// RegisterEx is an easy form to create KnockoutJS components
+//  name is the component name
+//  vmfunc is the ViewModel creator
+//  template is the html tempalte for the component
+//  cssRules would be directly embeded in the final html page, which can be ""
+func (co *ComponentsFuncs) RegisterEx(name string, vmfunc func(params *js.Object) interface{}, template, cssRules string) {
+	// embed the cssRules
+	if cssRules != "" {
+		style := dom.CreateElement("style")
+		style.InnerHTML = cssRules
+		dom.Body().AppendChild(style)
+	}
+	// register the component
+	co.Register(name, js.M{
+		"viewModel": vmfunc,
+		"template":  template,
+	})
+}
+
+func ko() *js.Object {
 	return js.Global.Get("ko")
 }
 
-func NewObservable(data interface{}) Observable {
-	return &Object{Global().Call("observable", data)}
+func NewObservable(data ...interface{}) *Observable {
+	if len(data) >= 1 {
+		return &Observable{ko().Call("observable", data[0])}
+	}
+	return &Observable{ko().Call("observable")}
 }
 
-func NewObservableArray(data interface{}) ObservableArray {
-	return &Object{Global().Call("observableArray", data)}
+func NewObservableArray(data ...interface{}) *ObservableArray {
+	if len(data) >= 1 {
+		return &ObservableArray{&Observable{ko().Call("observableArray", data[0])}}
+	}
+	return &ObservableArray{&Observable{ko().Call("observableArray")}}
 }
 
-func NewComputed(fn func() interface{}) Computed {
-	return &Object{Global().Call("computed", fn)}
+func NewComputed(fn func() interface{}) *Computed {
+	return &Computed{&Observable{ko().Call("computed", fn)}}
+}
+
+func NewWritableComputed(r func() interface{}, w func(interface{})) *WritableComputed {
+	return &WritableComputed{
+		&Computed{
+			&Observable{
+				ko().Call("computed", js.M{
+					"read":  r,
+					"write": w,
+				}),
+			},
+		},
+	}
+}
+
+func (ob *Computed) Dispose() {
+	ob.o.Call("dispose")
+}
+
+// Returns the current value of the computed observable without creating a dependency
+func (ob *Computed) Peek() *js.Object {
+	return ob.o.Call("peek")
+}
+
+// returns true for observables, observable arrays, and all computed observables.
+func IsObservable(data interface{}) bool {
+	return ko().Call("isObservable", data).Bool()
+}
+
+func IsComputed(data interface{}) bool {
+	return ko().Call("isComputed", data).Bool()
+}
+
+// returns true for observables, observable arrays, and writable computed observables
+func IsWritableObservable(data interface{}) bool {
+	return ko().Call("isWritableObservable", data).Bool()
 }
 
 // RegisterURLTemplateLoader register a new template loader which can be used to load
@@ -160,7 +253,7 @@ func RegisterURLTemplateLoader() {
 				// We need an array of DOM nodes, not a string.
 				// We can use the default loader to convert to the
 				// required format.
-				Components().Get("defaultLoader").Call("loadTemplate", name, data, callback)
+				Components().o.Get("defaultLoader").Call("loadTemplate", name, data, callback)
 			})
 		} else {
 			// Unrecognized config format. Let another loader handle it.
@@ -168,15 +261,31 @@ func RegisterURLTemplateLoader() {
 		}
 	}
 
-	Components().Get("loaders").Call("unshift", js.M{
+	Components().o.Get("loaders").Call("unshift", js.M{
 		"loadTemplate": loader,
 	})
 }
 
 func Unwrap(ob *js.Object) *js.Object {
-	return Global().Call("unwrap", ob)
+	return ko().Call("unwrap", ob)
 }
 
-func ApplyBindings(model interface{}) {
-	Global().Call("applyBindings", model)
+// In case you’re wondering what the parameters to ko.applyBindings do,
+//
+// the first parameter says what view model object you want to use with the declarative bindings it activates
+//
+// Optionally, you can pass a second parameter to define which part of the document you want to search for data-bind attributes.
+//
+// For example,
+// 	ko.applyBindings(myViewModel, document.getElementById('someElementId')).
+// This restricts the activation to the element with ID someElementId and its descendants, which is useful if you want to have multiple view models and associate each with a different region of the page.
+func ApplyBindings(args ...interface{}) {
+	if len(args) < 1 {
+		panic("ko.ApplyBindings takes at least ONE parameter")
+	}
+	if len(args) >= 2 {
+		ko().Call("applyBindings", args[0], args[1])
+		return
+	}
+	ko().Call("applyBindings", args[0])
 }

--- a/ko.go
+++ b/ko.go
@@ -27,6 +27,14 @@ type WritableComputed struct {
 	*Computed
 }
 
+type Subscription struct {
+	*js.Object
+}
+
+func (s *Subscription) Dispose() {
+	s.Object.Call("dispose")
+}
+
 func (ob *Observable) Set(data interface{}) {
 	ob.o.Invoke(data)
 }
@@ -35,10 +43,10 @@ func (ob *Observable) Get() *js.Object {
 	return ob.o.Invoke()
 }
 
-func (ob *Observable) Subscribe(fn func(*js.Object)) Disposer {
+func (ob *Observable) Subscribe(fn func(*js.Object)) *Subscription {
 	o := ob.o.Call("subscribe", fn)
-	return func() {
-		o.Invoke()
+	return &Subscription{
+		Object: o,
 	}
 }
 

--- a/ko.go
+++ b/ko.go
@@ -1,5 +1,6 @@
 // Package ko implements bindings to KnockoutJS.
 // It also has bindings for the Knockout Validation library found on https://github.com/Knockout-Contrib/Knockout-Validation
+// Using EnableSecureBinding make KnockoutJS works under CSP environments.
 package ko
 
 import "github.com/gopherjs/gopherjs/js"

--- a/mapping.go
+++ b/mapping.go
@@ -1,0 +1,122 @@
+package ko
+
+import (
+	"github.com/Archs/js/utils/property"
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// ViewModel can be used to wrap ko vm object
+type ViewModel struct {
+	*js.Object
+}
+
+type Mapper struct {
+	*js.Object
+	data    interface{}
+	options *js.Object
+	target  interface{}
+}
+
+func Mapping() *Mapper {
+	return &Mapper{
+		Object: ko().Get("mapping"),
+	}
+}
+
+func (m *Mapper) args() []interface{} {
+	args := []interface{}{m.data}
+	if m.options != nil {
+		args = append(args, m.options)
+	}
+	if m.target != nil {
+		if m.options == nil {
+			args = append(args, js.M{})
+		}
+		args = append(args, m.target)
+	}
+	return args
+}
+
+func (m *Mapper) FromJS(data interface{}) (vm *ViewModel) {
+	vm = new(ViewModel)
+	m.data = data
+	vm.Object = m.Object.Call("fromJS", m.args()...)
+	return
+}
+
+// Specifying the target to update, can be a *ViewModel or a *js.Object
+// or a struct with *js.Object embeded which is a ViewModel then
+func (m *Mapper) Target(obj interface{}) *Mapper {
+	m.target = obj
+	return m
+}
+
+func (m *Mapper) ToJS(vm *ViewModel) *js.Object {
+	return m.Object.Call("toJS", vm.Object)
+}
+
+func (m *Mapper) FromJSON(data string) (vm *ViewModel) {
+	vm = new(ViewModel)
+	m.data = data
+	vm.Object = m.Object.Call("fromJSON", m.args()...)
+	return
+}
+
+func (m *Mapper) ToJSON(vm *ViewModel) string {
+	return m.Object.Call("toJSON", vm.Object).String()
+}
+
+// Set mapping options
+func (m *Mapper) Option(key string, value interface{}) *Mapper {
+	if m.options == nil {
+		m.options = js.Global.Get("Object").New()
+	}
+	m.options.Set(key, value)
+	return m
+}
+
+// Ignoring certain properties using “ignore”
+func (m *Mapper) Ignore(properties ...string) *Mapper {
+	return m.Option("ignore", properties)
+}
+
+// Observing only certain properties using “observe”
+func (m *Mapper) Observe(properties ...string) *Mapper {
+	return m.Option("observe", properties)
+}
+
+// func isArray(i interface{}) bool {
+// 	v := reflect.ValueOf(i)
+// 	v = reflect.Indirect(v)
+// 	if v.Type().Kind() == reflect.Array {
+// 		return true
+// 	}
+// 	return false
+// }
+
+func (v *ViewModel) Set(keyPath string, value interface{}) {
+	obj := property.Get(v.Object, keyPath)
+	if obj == js.Undefined {
+		// if isArray(value) {
+		// 	v.Set(key, NewObservableArray(value))
+		// } else {
+		// 	v.Set(key, NewObservable(value))
+		// }
+		panic("ViewModel has no key: " + keyPath)
+	} else {
+		obj.Invoke(value)
+	}
+}
+
+func (v *ViewModel) Get(keyPath string) *js.Object {
+	obj := property.Get(v.Object, keyPath)
+	if obj == js.Undefined {
+		return obj
+	}
+	return obj.Invoke()
+}
+
+func (v *ViewModel) Update(data interface{}) *ViewModel {
+	Mapping().Call("fromJS", data, v.Object)
+	return v
+}

--- a/validation.go
+++ b/validation.go
@@ -2,16 +2,16 @@ package ko
 
 import "github.com/gopherjs/gopherjs/js"
 
-type ValidatedObservable interface {
-	IsValid() bool
+type ValidatedObservable struct {
+	*Observable
 }
 
-func NewValidatedObservable(data interface{}) ValidatedObservable {
-	return &Object{Global().Call("validatedObservable", data)}
+func NewValidatedObservable(data interface{}) *ValidatedObservable {
+	return &ValidatedObservable{&Observable{ko().Call("validatedObservable", data)}}
 }
 
-func (ob *Object) IsValid() bool {
-	return ob.Call("isValid").Bool()
+func (v *ValidatedObservable) IsValid() bool {
+	return v.o.Call("isValid").Bool()
 }
 
 type ValidationFuncs struct {
@@ -19,7 +19,7 @@ type ValidationFuncs struct {
 }
 
 func Validation() *ValidationFuncs {
-	return &ValidationFuncs{Object: Global().Get("validation")}
+	return &ValidationFuncs{Object: ko().Get("validation")}
 }
 
 func (v *ValidationFuncs) Init(config js.M) {


### PR DESCRIPTION
changes made here:

1. KnockoutJS Secure Bindings API
2. Knockout Mapping API
3. No Interface used (thus not quite compitable with origin implementation, thus no pull request) to avoid some problems with `GopherJS`, see: https://github.com/mibitzi/gopherjs-ko/issues/1

